### PR TITLE
setting a default tile format to png

### DIFF
--- a/controller/index.js
+++ b/controller/index.js
@@ -424,6 +424,12 @@ var Controller = extend({
     var key,
       layer = req.params.layer || 0;
 
+    // if no format given default to png 
+    if ( !req.params.format ){
+      req.params.format = 'png';
+    }
+
+    // Get the tile and send the response to the client
     var _send = function( err, data ){
       req.params.key = key + ':' + layer;
       Tiles.get( req.params, data[0], function(err, tile){

--- a/routes/index.js
+++ b/routes/index.js
@@ -88,6 +88,11 @@ module.exports = {
   'get /agol/:id/:item/:layer/tiles/:z/:x/:y.:format': {
     controller: 'agol',
     action: 'tiles'
-  }
+  },
+
+  'get /agol/:id/:item/:layer/tiles/:z/:x/:y': {
+    controller: 'agol',
+    action: 'tiles'
+  },
 
 };


### PR DESCRIPTION
@patrickarlt pointed out that tiles endpoints w/o a mime-type extension should default to png. This does that. 
